### PR TITLE
ACS sample scripts: update link to documentation

### DIFF
--- a/BARVendor/ACS_scripts/acs_ibmstor.sh
+++ b/BARVendor/ACS_scripts/acs_ibmstor.sh
@@ -7,7 +7,7 @@
 # Purpose: implement the scripted interface for DB2 ACS using IBM System Storage DS4800 and Storage Manager.
 # This script is called by DB2 to make snapshot backups of paths provided by DB2.
 # 
-# Please see developerwork article for details: https://www.ibm.com/developerworks/data/library/techarticle/dm-1506scriptdb2copy4/dm-1506scriptdb2copy4-pdf.pdf
+# Please see https://github.com/IBM/db2-samples/tree/master/BARVendor/ACS_scripts/acs_ibmstor.pdf for details.
 #
 # The following sample of source code ("Sample") is owned by International
 # Business Machines Corporation or one of its subsidiaries ("IBM") and is

--- a/BARVendor/ACS_scripts/dm-1310acs_lvm.sh
+++ b/BARVendor/ACS_scripts/dm-1310acs_lvm.sh
@@ -6,7 +6,7 @@
 # 
 # Purpose: implement the scripted interface for DB2 ACS using Linux LVM.
 # 
-# Please see developerwork article for details: https://www.ibm.com/developerworks/data/library/techarticle/dm-1310scriptdb2copy2/dm-1310scriptdb2copy2-pdf.pdf
+# Please see https://github.com/IBM/db2-samples/tree/master/BARVendor/ACS_scripts/acs_lvm.pdf for details.
 #
 # The following sample of source code ("Sample") is owned by International
 # Business Machines Corporation or one of its subsidiaries ("IBM") and is

--- a/BARVendor/ACS_scripts/dm-1311acs_gpfs.sh
+++ b/BARVendor/ACS_scripts/dm-1311acs_gpfs.sh
@@ -8,7 +8,7 @@
 # script is called by DB2 to make GPFS snapshot backups of paths
 # provided by DB2.
 # 
-# Please see developerwork article for details: https://www.ibm.com/developerworks/data/library/techarticle/dm-1311scriptdb2copy3/dm-1311scriptdb2copy3-pdf.pdf
+# Please see https://github.com/IBM/db2-samples/tree/master/BARVendor/ACS_scripts/acs_gpfs.pdf for details.
 #
 # The following sample of source code ("Sample") is owned by International
 # Business Machines Corporation or one of its subsidiaries ("IBM") and is


### PR DESCRIPTION
Update the outdated link referring to IBM developerworks to new location on github-com/IBM/db2-samples